### PR TITLE
Add grid layout and hero skeleton

### DIFF
--- a/docs/hero-placeholder.svg
+++ b/docs/hero-placeholder.svg
@@ -1,0 +1,4 @@
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" preserveAspectRatio="xMidYMid slice">
+  <rect width="800" height="600" fill="#e0e0e0"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#aaaaaa" font-family="Arial, sans-serif">Placeholder</text>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,12 +11,17 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="ai-dev-container">
-    <!-- Hero Section -->
-    <header class="ai-dev-header">
-      <h1>Build Smarter Infill Projects</h1>
-      <p>AI-powered tools for small and mid-size developers. Simple to use, built to scale.</p>
-    </header>
+  <div class="ai-dev-container page gap-2">
+    <section class="hero">
+      <div class="hero-copy">
+        <p class="eyebrow">AI Tools for Urban Infill</p>
+        <h1>Build Smarter Infill Projects</h1>
+        <p class="sub-headline">AI-powered tools for small and mid-size developers. Simple to use, built to scale.</p>
+      </div>
+      <div class="hero-visual">
+        <img src="hero-placeholder.svg" alt="" width="800" height="600" />
+      </div>
+    </section>
 
     <main>
         <p class="ai-dev-intro">Use advanced AI to scout lots, generate concepts, and streamline approvals. Our lean approach keeps you focused on building homes, not wrangling data.</p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -188,3 +188,56 @@ body {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* Layout */
+.page {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: var(--ai-dev-space);
+}
+
+/* Gap utilities */
+.gap-1 { gap: calc(var(--ai-dev-space)); }
+.gap-2 { gap: calc(var(--ai-dev-space) * 2); }
+.gap-3 { gap: calc(var(--ai-dev-space) * 3); }
+
+/* Hero */
+.hero {
+  position: relative;
+  padding-block: calc(var(--ai-dev-space) * 4);
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, var(--ai-dev-color-accent), transparent 70%);
+  opacity: 0.3;
+  pointer-events: none;
+  z-index: -1;
+}
+.hero-copy {
+  grid-column: 1 / -1;
+}
+.hero-visual {
+  grid-column: 1 / -1;
+}
+.eyebrow {
+  font-size: 0.875rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin: 0 0 0.5rem 0;
+  color: var(--ai-dev-color-accent);
+}
+.sub-headline {
+  font-size: clamp(1.125rem, 2.5vw, 1.25rem);
+  margin-top: 0;
+}
+
+@media (min-width: 900px) {
+  .hero-copy {
+    grid-column: span 6;
+  }
+  .hero-visual {
+    grid-column: span 6;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `.page` grid wrapper with gap utilities
- create radial-gradient hero background
- refactor hero markup into copy/visual columns
- add placeholder hero image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ad972b1948328aeb4d332dcb8c5aa