### PR TITLE
Add accessible email signup

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,29 +53,48 @@
     </section>
 
     <!-- Email Capture -->
-    <form class="ai-dev-form" action="https://formspree.io/f/your-form-id" method="POST">
-      <label for="email" class="ai-dev-sr-only">Email</label>
-      <input class="ai-dev-input" id="email" name="email" type="email" placeholder="your@email.com" required>
-      <button class="ai-dev-btn" type="submit">Keep Me Posted</button>
-    </form>
+    <div id="signup-wrapper" aria-live="polite">
+      <form class="signup" action="https://formspree.io/f/your-form-id" method="POST">
+        <label for="signup-email" class="ai-dev-sr-only">Email</label>
+        <input id="signup-email" name="email" type="email" placeholder="you@example.com" required>
+        <button type="submit">Get Early Access</button>
+      </form>
+    </div>
     </main>
   </div>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const wrapper = document.getElementById('signup-wrapper');
+      const form = wrapper.querySelector('form.signup');
+      const emailInput = document.getElementById('signup-email');
 
-  <script>
-    const form = document.querySelector('.ai-dev-form');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const data = new FormData(form);
-      const res = await fetch(form.action, {
-        method: form.method,
-        body: data,
-        headers: { 'Accept': 'application/json' }
-      });
-      if (res.ok) {
-        form.innerHTML = '<p>Thanks for signing up! Check your inbox soon.</p>';
-      } else {
-        alert('Sorry, there was a problem.');
+      if (window.matchMedia('(pointer:fine)').matches) {
+        emailInput.setAttribute('autofocus', 'autofocus');
       }
+
+      emailInput.addEventListener('input', () => {
+        if (/^.+@.+\..+$/.test(emailInput.value) || emailInput.value === '') {
+          emailInput.setCustomValidity('');
+        } else {
+          emailInput.setCustomValidity('Please enter a valid email address.');
+        }
+      });
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const originalHeight = form.offsetHeight;
+        wrapper.style.height = originalHeight + 'px';
+        const res = await fetch(form.action, {
+          method: form.method,
+          body: data,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.ok) {
+          wrapper.innerHTML = '<p class="signup-thankyou" tabindex="-1">Thanks—check your inbox!</p>';
+          wrapper.firstElementChild.focus();
+        }
+      });
     });
   </script>
 </body>

--- a/docs/style.css
+++ b/docs/style.css
@@ -147,12 +147,64 @@ body {
   color: var(--ai-dev-color-bg);
 }
 
+.signup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-block-end: calc(var(--ai-dev-space) * 4);
+}
+
+.signup input[type="email"] {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: "Inter", system-ui, sans-serif;
+  border: 2px solid var(--ai-dev-color-accent);
+  border-radius: var(--ai-dev-radius);
+  background: transparent;
+  color: inherit;
+}
+
+.signup input[type="email"]:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--ai-dev-color-accent);
+}
+
+.signup button {
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: transparent;
+  color: var(--ai-dev-color-text);
+  border: 2px solid var(--ai-dev-color-accent);
+  border-radius: var(--ai-dev-radius);
+  cursor: pointer;
+  transition: background var(--ai-dev-timing), color var(--ai-dev-timing);
+}
+
+.signup button:hover,
+.signup button:focus {
+  background: var(--ai-dev-color-accent);
+  color: var(--ai-dev-color-bg);
+}
+
+.signup-thankyou {
+  margin: 0;
+  padding: 0.75rem 1rem;
+}
+
 @media (min-width: 600px) {
   .ai-dev-header {
     text-align: left;
   }
   .ai-dev-form {
     flex-direction: row;
+    justify-content: center;
+  }
+  .signup {
+    flex-wrap: nowrap;
     justify-content: center;
   }
   .ai-dev-bullets {


### PR DESCRIPTION
## Summary
- implement new signup form with inline validation and success feedback
- add desktop-only autofocus and aria-live handling
- style the signup block with flex layout

## Testing
- `tidy -errors -q docs/index.html`
- `npx --yes lighthouse docs/index.html --quiet --chrome-flags="--headless"` *(fails: Unable to connect to Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_685ada114f548328b28b8d38d7868379