### PR TITLE
Add menu bar and demo/signup pages

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo - SIGHTHOUND</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="menu-bar">
+    <div class="menu-container">
+      <div class="brand">S I G H T H O U N D</div>
+      <nav class="menu-items">
+        <a href="demo.html">demo</a>
+        <a href="signup.html">sign up</a>
+      </nav>
+    </div>
+  </header>
+  <div class="ai-dev-container page gap-2">
+    <main>
+      <h1>Demo</h1>
+      <p>Demo page coming soon.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,15 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <header class="menu-bar">
+    <div class="menu-container">
+      <div class="brand">S I G H T H O U N D</div>
+      <nav class="menu-items">
+        <a href="demo.html">demo</a>
+        <a href="signup.html">sign up</a>
+      </nav>
+    </div>
+  </header>
   <div class="ai-dev-container page gap-2">
     <section class="hero">
       <div class="hero-copy">

--- a/docs/signup.html
+++ b/docs/signup.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sign Up - SIGHTHOUND</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="menu-bar">
+    <div class="menu-container">
+      <div class="brand">S I G H T H O U N D</div>
+      <nav class="menu-items">
+        <a href="demo.html">demo</a>
+        <a href="signup.html">sign up</a>
+      </nav>
+    </div>
+  </header>
+  <div class="ai-dev-container page gap-2">
+    <main>
+      <h1>Sign Up</h1>
+      <div id="signup-wrapper" aria-live="polite">
+        <form class="signup" action="https://formspree.io/f/your-form-id" method="POST">
+          <label for="signup-email" class="ai-dev-sr-only">Email</label>
+          <input id="signup-email" name="email" type="email" placeholder="you@example.com" required>
+          <button type="submit">Get Early Access</button>
+        </form>
+      </div>
+    </main>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const wrapper = document.getElementById('signup-wrapper');
+      const form = wrapper.querySelector('form.signup');
+      const emailInput = document.getElementById('signup-email');
+
+      if (window.matchMedia('(pointer:fine)').matches) {
+        emailInput.setAttribute('autofocus', 'autofocus');
+      }
+
+      emailInput.addEventListener('input', () => {
+        if (/^.+@.+\..+$/.test(emailInput.value) || emailInput.value === '') {
+          emailInput.setCustomValidity('');
+        } else {
+          emailInput.setCustomValidity('Please enter a valid email address.');
+        }
+      });
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const originalHeight = form.offsetHeight;
+        wrapper.style.height = originalHeight + 'px';
+        const res = await fetch(form.action, {
+          method: form.method,
+          body: data,
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.ok) {
+          wrapper.innerHTML = '<p class="signup-thankyou" tabindex="-1">Thanks—check your inbox!</p>';
+          wrapper.firstElementChild.focus();
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -29,6 +29,34 @@ body {
   background: var(--ai-dev-color-bg);
   color: var(--ai-dev-color-text);
   line-height: 1.6;
+  padding-top: 3.5rem; /* space for fixed menu */
+}
+
+/* Simple fixed menu bar */
+.menu-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: var(--ai-dev-color-bg);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+.menu-container {
+  max-width: 90rem;
+  margin-inline: auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.menu-items a {
+  margin-left: 1rem;
+  text-decoration: none;
+  color: inherit;
+  font-weight: 700;
 }
 
 .ai-dev-sr-only {


### PR DESCRIPTION
## Summary
- design a fixed menu bar with brand and navigation
- insert menu bar on all pages
- add demo and signup pages

## Testing
- `bash -lc 'ls docs'`

------
https://chatgpt.com/codex/tasks/task_e_685c691cd2008328afd8da97c3982af7