### PR TITLE
Improve signup layout and add SEO copy

### DIFF
--- a/docs/signup.html
+++ b/docs/signup.html
@@ -22,13 +22,23 @@
   <div class="ai-dev-container page gap-2">
     <main>
       <h1>Sign Up</h1>
-      <div id="signup-wrapper" aria-live="polite">
-        <form class="signup" action="https://formspree.io/f/your-form-id" method="POST">
-          <label for="signup-email" class="ai-dev-sr-only">Email</label>
-          <input id="signup-email" name="email" type="email" placeholder="you@example.com" required>
-          <button type="submit">Get Early Access</button>
-        </form>
+      <div class="signup-container">
+        <div id="signup-wrapper" aria-live="polite">
+          <form class="signup" action="https://formspree.io/f/your-form-id" method="POST">
+            <label for="signup-email" class="ai-dev-sr-only">Email</label>
+            <input id="signup-email" name="email" type="email" placeholder="you@example.com" required>
+            <button type="submit">Get Early Access</button>
+          </form>
+        </div>
       </div>
+
+      <section class="seo-text">
+        <h2>Why Teams Use Basecamp</h2>
+        <p>Basecamp helps groups stay organized with an intuitive interface that unifies to-do lists, messaging, schedules, and file storage. Instead of juggling multiple apps, your entire project lives in one place.</p>
+        <p>The platform's message boards and real-time chat keep conversations tidy, while its task management tools ensure that everyone knows what's next. Automatic check-ins simplify status reporting so you spend less time in meetings and more time building.</p>
+        <p>Remote teams appreciate how Basecamp streamlines collaboration. Integrated calendars, file sharing, and progress tracking make it easier to coordinate work across time zones.</p>
+        <p>Learn more about Basecamp's approach to modern project management at <a href="https://basecamp.com/">basecamp.com</a>.</p>
+      </section>
     </main>
   </div>
   <script>

--- a/docs/style.css
+++ b/docs/style.css
@@ -176,11 +176,30 @@ body {
   color: var(--ai-dev-color-bg);
 }
 
+/* Container for signup form */
+.signup-container {
+  width: 100%;
+  max-width: 40rem;
+  margin-inline: auto;
+  display: flex;
+  justify-content: center;
+}
+
+/* SEO text section */
+.seo-text {
+  max-width: 40rem;
+  margin-inline: auto;
+  padding-block: calc(var(--ai-dev-space) * 2);
+  line-height: 1.7;
+}
+
 .signup {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.5rem;
   margin-block-end: calc(var(--ai-dev-space) * 4);
+  width: 100%;
 }
 
 .signup input[type="email"] {


### PR DESCRIPTION
## Summary
- center the signup form in its own container
- add Basecamp-focused SEO copy on the signup page
- style the new container and text section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c6cad8fa08328a47e92b961819b1a