### PR TITLE
Implement AI editor service and edit endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,19 @@ npm install
 npm start
 ```
 
-The server provides a single endpoint:
+The server provides a couple endpoints:
 
 ```
 GET /api/content/:pageName
 ```
 
 which returns the contents of `content/<pageName>.json`.
+
+```
+POST /api/edit/:pageName
+```
+
+Sends the current JSON and a user prompt to the Gemini API to modify the page
+content. The request body must include a `prompt` field. The updated JSON is
+saved back to `content/<pageName>.json` and returned in the response. Set the
+`GEMINI_API_KEY` environment variable so the server can call the API.

--- a/aiEditorService.js
+++ b/aiEditorService.js
@@ -1,0 +1,56 @@
+const fetch = global.fetch || ((...args) => import('node-fetch').then(({default: f}) => f(...args)));
+const API_KEY = process.env.GEMINI_API_KEY;
+const MODEL = process.env.GEMINI_MODEL || 'gemini-pro';
+
+if (!API_KEY) {
+  console.warn('Warning: GEMINI_API_KEY is not set. AI editing will fail.');
+}
+
+const SYSTEM_PROMPT = `You are a JSON editing assistant. Only output strict JSON with no explanations. Keep the existing keys unless the user's instruction requires changes.`;
+
+function extractJson(text) {
+  const match = text.match(/\{[\s\S]*\}/);
+  return match ? match[0] : text;
+}
+
+async function callGemini(promptBody) {
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${API_KEY}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(promptBody)
+  });
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Gemini API error ${res.status}: ${errText}`);
+  }
+  return res.json();
+}
+
+async function getAiModifiedJson(currentJson, userPrompt, retries = 2) {
+  const promptBody = {
+    contents: [
+      { role: 'user', parts: [{ text: SYSTEM_PROMPT }] },
+      { role: 'user', parts: [{ text: `Current JSON:\n${JSON.stringify(currentJson, null, 2)}` }] },
+      { role: 'user', parts: [{ text: `Edit command:\n${userPrompt}` }] }
+    ]
+  };
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const data = await callGemini(promptBody);
+      const aiText = data.candidates?.[0]?.content?.parts?.[0]?.text;
+      if (!aiText) {
+        throw new Error('No content from AI');
+      }
+      const json = JSON.parse(extractJson(aiText));
+      return json;
+    } catch (err) {
+      if (attempt === retries) {
+        throw err;
+      }
+    }
+  }
+}
+
+module.exports = { getAiModifiedJson };

--- a/server.js
+++ b/server.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const fs = require('fs').promises;
 const path = require('path');
+const { getAiModifiedJson } = require('./aiEditorService');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
 
 app.get('/api/content/:pageName', async (req, res) => {
   const pageName = req.params.pageName;
@@ -12,6 +15,38 @@ app.get('/api/content/:pageName', async (req, res) => {
   try {
     const data = await fs.readFile(filePath, 'utf8');
     res.type('application/json').status(200).send(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.status(404).json({ error: 'Content not found' });
+    } else {
+      console.error(err);
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
+  }
+});
+
+app.post('/api/edit/:pageName', async (req, res) => {
+  const pageName = req.params.pageName;
+  const prompt = req.body && req.body.prompt;
+  if (typeof prompt !== 'string') {
+    return res.status(400).json({ error: 'Prompt is required' });
+  }
+  const filePath = path.join(__dirname, 'content', `${pageName}.json`);
+
+  try {
+    const data = await fs.readFile(filePath, 'utf8');
+    const currentJson = JSON.parse(data);
+
+    let updatedJson;
+    try {
+      updatedJson = await getAiModifiedJson(currentJson, prompt);
+    } catch (err) {
+      console.error('AI service error:', err);
+      return res.status(502).json({ error: 'AI service error' });
+    }
+
+    await fs.writeFile(filePath, JSON.stringify(updatedJson, null, 2));
+    res.status(200).json(updatedJson);
   } catch (err) {
     if (err.code === 'ENOENT') {
       res.status(404).json({ error: 'Content not found' });


### PR DESCRIPTION
## Summary
- add `aiEditorService.js` to talk to Gemini and return JSON
- update server to expose POST `/api/edit/:pageName` and wire up AI service
- document the new endpoint and environment variable in README

## Testing
- `npm test` *(fails: no test specified)*
- `npm install`
- `node server.js` *(runs and logs warning about missing GEMINI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_685d975e5a008328b3ffc25d39366720