### PR TITLE
Add AI command bar

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -486,3 +486,8 @@ body {
 .modal-form input[type="file"] {
   width: 100%;
 }
+
+/* AI command bar */
+.ai-command-bar { position: fixed; bottom: 0; left: 0; right: 0; display: flex; gap: var(--ai-dev-space); padding: var(--ai-dev-space); background: var(--ai-dev-color-bg); border-top: 1px solid #ccc; z-index: 1500; }
+.ai-command-bar .status-msg { margin-left: var(--ai-dev-space); align-self: center; }
+.ai-command-bar .status-msg.error { color: red; }

--- a/frontend/app/demo/page.tsx
+++ b/frontend/app/demo/page.tsx
@@ -6,6 +6,7 @@ import ActionQueue from '../../components/ActionQueue'
 import PipelineTable from '../../components/PipelineTable'
 import AddPropertyModal from '../../components/AddPropertyModal'
 import PropertyDetailsModal from '../../components/PropertyDetailsModal'
+import AiCommandBar from '../../components/AiCommandBar'
 import data from '../../data/demo.json'
 
 export default function DemoPage() {
@@ -57,6 +58,7 @@ export default function DemoPage() {
         documentsLabel={modals.propertyDetails.documentsLabel}
         saveText={modals.propertyDetails.saveText}
       />
+      <AiCommandBar pageName="demo" />
     </>
   )
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -486,3 +486,8 @@ body {
 .modal-form input[type="file"] {
   width: 100%;
 }
+
+/* AI command bar */
+.ai-command-bar { position: fixed; bottom: 0; left: 0; right: 0; display: flex; gap: var(--ai-dev-space); padding: var(--ai-dev-space); background: var(--ai-dev-color-bg); border-top: 1px solid #ccc; z-index: 1500; }
+.ai-command-bar .status-msg { margin-left: var(--ai-dev-space); align-self: center; }
+.ai-command-bar .status-msg.error { color: red; }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,6 +2,7 @@ import MenuBar from '../components/MenuBar'
 import Hero from '../components/Hero'
 import FeatureCard from '../components/FeatureCard'
 import SignupForm from '../components/SignupForm'
+import AiCommandBar from '../components/AiCommandBar'
 import data from '../data/index.json'
 
 export default function Home() {
@@ -23,6 +24,7 @@ export default function Home() {
           </main>
         </div>
       </div>
+      <AiCommandBar pageName="index" />
     </>
   )
 }

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,5 +1,6 @@
 import MenuBar from '../../components/MenuBar'
 import SignupForm from '../../components/SignupForm'
+import AiCommandBar from '../../components/AiCommandBar'
 import data from '../../data/signup.json'
 
 export default function SignupPage() {
@@ -21,6 +22,7 @@ export default function SignupPage() {
           </section>
         </main>
       </div>
+      <AiCommandBar pageName="signup" />
     </>
   )
 }

--- a/frontend/components/AiCommandBar.tsx
+++ b/frontend/components/AiCommandBar.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useState } from 'react'
+
+export default function AiCommandBar({ pageName }: { pageName: string }) {
+  const [command, setCommand] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState<{ text: string; error?: boolean } | null>(null)
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (!command) return
+    setLoading(true)
+    setMessage(null)
+    try {
+      const res = await fetch(`/api/edit/${pageName}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: command })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => null)
+        throw new Error(err?.error || 'Request failed')
+      }
+      await res.json()
+      setMessage({ text: 'Success!' })
+      setCommand('')
+    } catch (err: any) {
+      setMessage({ text: err.message || 'Error', error: true })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form className="ai-command-bar" onSubmit={handleSubmit}>
+      <label htmlFor="ai-command" className="ai-dev-sr-only">
+        AI command
+      </label>
+      <input
+        id="ai-command"
+        type="text"
+        className="ai-dev-input"
+        placeholder="Edit command"
+        value={command}
+        onChange={(e) => setCommand(e.target.value)}
+        disabled={loading}
+      />
+      <button type="submit" className="ai-dev-btn" disabled={loading}>
+        {loading ? 'Submitting...' : 'Submit'}
+      </button>
+      {message && (
+        <span className={`status-msg${message.error ? ' error' : ''}`}>{message.text}</span>
+      )}
+    </form>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable `AiCommandBar` component
- style the command bar for both Next.js and static site
- place the command bar on all pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d9abb97148328bbca518e12ffa31f