### PR TITLE
Add San Mateo landscaping page and navigation link

### DIFF
--- a/sighthound_site/cart.html
+++ b/sighthound_site/cart.html
@@ -12,6 +12,7 @@
             <a href="index.html" class="site-title">Sighthound</a>
             <ul class="nav-links">
                 <li><a href="store.html">Shop</a></li>
+                <li><a href="san-mateo-landscaping.html">Landscaping</a></li>
                 <li><a href="cart.html">Cart<span class="cart-count">0</span></a></li>
             </ul>
         </div>

--- a/sighthound_site/index.html
+++ b/sighthound_site/index.html
@@ -12,6 +12,7 @@
             <a href="index.html" class="site-title">Sighthound</a>
             <ul class="nav-links">
                 <li><a href="store.html">Shop</a></li>
+                <li><a href="san-mateo-landscaping.html">Landscaping</a></li>
                 <li><a href="cart.html">Cart<span class="cart-count">0</span></a></li>
             </ul>
         </div>

--- a/sighthound_site/san-mateo-landscaping.html
+++ b/sighthound_site/san-mateo-landscaping.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Native San Mateo Landscaping – Sighthound Design Studios</title>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+    <header>
+        <div class="header-inner">
+            <a href="index.html" class="site-title">Sighthound</a>
+            <ul class="nav-links">
+                <li><a href="store.html">Shop</a></li>
+                <li><a href="san-mateo-landscaping.html">Landscaping</a></li>
+                <li><a href="cart.html">Cart<span class="cart-count">0</span></a></li>
+            </ul>
+        </div>
+    </header>
+    <main>
+        <h1>Native San Mateo Landscaping Solutions</h1>
+        <p>
+            The San Mateo region enjoys a mild coastal climate that supports a rich
+            variety of native plants. Incorporating species such as California
+            fescue, coast live oak, and sticky monkey flower creates resilient
+            gardens that thrive with minimal irrigation.
+        </p>
+        <h2>Why Choose Native Plants</h2>
+        <ul>
+            <li>Drought-tolerant choices reduce water consumption.</li>
+            <li>Native species provide habitat for local pollinators and birds.</li>
+            <li>Once established, these plants require less maintenance than many exotic varieties.</li>
+        </ul>
+        <h2>Potted Plants vs. In-Ground Plantings</h2>
+        <p>
+            Potted plants offer flexibility for patios and renters. Containers let you
+            control soil quality and move specimens to chase the sun, but they can dry
+            out quickly and may limit root development. Planting directly in the soil
+            encourages deep rooting and a more self-sustaining landscape, though it
+            requires choosing species well-suited to their location from the start.
+        </p>
+    </main>
+    <footer>
+        <p>&copy; <span id="year"></span> Sighthound Design Studios.</p>
+    </footer>
+    <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/sighthound_site/store.html
+++ b/sighthound_site/store.html
@@ -12,6 +12,7 @@
             <a href="index.html" class="site-title">Sighthound</a>
             <ul class="nav-links">
                 <li><a href="store.html">Shop</a></li>
+                <li><a href="san-mateo-landscaping.html">Landscaping</a></li>
                 <li><a href="cart.html">Cart<span class="cart-count">0</span></a></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- add dedicated page outlining native San Mateo landscaping solutions and comparison of potted vs in-ground plants
- add "Landscaping" link to header navigation across static pages

## Testing
- `npm test` (fails: could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689a3c1fc714832895a3442f483b82e7